### PR TITLE
Bunch Ring Wrapper nodes added to ENTRANCE and EXIT instead of BODY 

### DIFF
--- a/py/orbit/teapot/teapot.py
+++ b/py/orbit/teapot/teapot.py
@@ -165,9 +165,14 @@ class TEAPOT_Ring(TEAPOT_Lattice):
 		"""
 		TEAPOT_Lattice.initialize(self)
 		for node in self.getNodes():
-			bunchwrapper = BunchWrapTEAPOT("Bunch Wrap")
-			bunchwrapper.getParamsDict()["ring_length"] = self.getLength()
-			node.addChildNode(bunchwrapper, AccNode.BODY)			
+			length = node.getLength()
+			if(length > 0.):
+				bunchwrapper = BunchWrapTEAPOT(node.getName()+":Bunch_Wrap:Entrance")
+				bunchwrapper.getParamsDict()["ring_length"] = self.getLength()
+				node.addChildNode(bunchwrapper, AccNode.ENTRANCE)
+				bunchwrapper = BunchWrapTEAPOT(node.getName()+":Bunch_Wrap:Exit")
+				bunchwrapper.getParamsDict()["ring_length"] = self.getLength()
+				node.addChildNode(bunchwrapper, AccNode.EXIT)				
 		#---- adding turn counter node at the end of lattice
 		turn_counter = TurnCounterTEAPOT()
 		self.getNodes().append(turn_counter)


### PR DESCRIPTION
The Bunch Ring Wrapper nodes were added to the Body of any node as child nodes. That created a problem for changing the number of parts in the node even right after the lattice creation. It was wrong. Now the Bunch Wrappers are added to the entrance and exit of all non-zero length nodes.